### PR TITLE
:tada: updated to manifest 3 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "name": "Fearless Acronyms",
   "description": "Select an acronym to expand it.",
   "version": "1.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
 
-  "browser_action": {
+  "action": {
     "default_icon": "./images/fearless-logo128.png",
     "default_popup": "./search-dropdown/search.html"
   },


### PR DESCRIPTION
mv2 will become unsupported in 2023. Updated to Manifest V3 per [this documentation](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/)

I followed the documentation, but it is always possible I missed something. Followed error reports until I no longer saw errors. Plugin works as it should. 